### PR TITLE
revised norm and log argument definitions

### DIFF
--- a/R/MRexperiment2biom.R
+++ b/R/MRexperiment2biom.R
@@ -4,8 +4,8 @@
 #' 
 #' @param obj The MRexperiment object.
 #' @param id Optional id for the biom matrix.
-#' @param norm Normalized data?
-#' @param log Logged data?
+#' @param norm normalize count table
+#' @param log log2 transform count table
 #' @param sl scaling factor for normalized counts.
 #' @param qiimeVersion Format fData according to QIIME specifications (assumes only taxonomy in fData).
 #' @return A biom object.


### PR DESCRIPTION
The current argument descriptions are a bit vague. I think these more clearly indicate that the count table count table is normalized and log2 transformed before assigned to the biom data slot.