### PR TITLE
Fix failing unit tests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: metagenomeSeq
 Title: Statistical analysis for sparse high-throughput sequencing
-Version: 1.39.0
+Version: 1.40.0
 Date: 2019-07-12
 Author: Joseph Nathaniel Paulson, Nathan D. Olson, Domenick J. Braccia, 
     Justin Wagner, Hisham Talukder, Mihai Pop, Hector Corrada Bravo

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: metagenomeSeq
 Title: Statistical analysis for sparse high-throughput sequencing
-Version: 1.33.0
+Version: 1.34.0
 Date: 2019-07-12
 Author: Joseph Nathaniel Paulson, Nathan D. Olson, Domenick J. Braccia, 
     Justin Wagner, Hisham Talukder, Mihai Pop, Hector Corrada Bravo

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: metagenomeSeq
 Title: Statistical analysis for sparse high-throughput sequencing
-Version: 1.43.0
+Version: 1.44.0
 Date: 2019-07-12
 Author: Joseph Nathaniel Paulson, Nathan D. Olson, Domenick J. Braccia, 
     Justin Wagner, Hisham Talukder, Mihai Pop, Hector Corrada Bravo

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: metagenomeSeq
 Title: Statistical analysis for sparse high-throughput sequencing
-Version: 1.36.0
+Version: 1.37.0
 Date: 2019-07-12
 Author: Joseph Nathaniel Paulson, Nathan D. Olson, Domenick J. Braccia, 
     Justin Wagner, Hisham Talukder, Mihai Pop, Hector Corrada Bravo

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: metagenomeSeq
 Title: Statistical analysis for sparse high-throughput sequencing
-Version: 1.31.0
+Version: 1.32.0
 Date: 2019-07-12
 Author: Joseph Nathaniel Paulson, Nathan D. Olson, Domenick J. Braccia, 
     Justin Wagner, Hisham Talukder, Mihai Pop, Hector Corrada Bravo

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: metagenomeSeq
 Title: Statistical analysis for sparse high-throughput sequencing
-Version: 1.47.0
+Version: 1.48.0
 Date: 2024-03-12
 Author: Joseph Nathaniel Paulson, Nathan D. Olson, Domenick J. Braccia, 
     Justin Wagner, Hisham Talukder, Mihai Pop, Hector Corrada Bravo

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: metagenomeSeq
 Title: Statistical analysis for sparse high-throughput sequencing
-Version: 1.46.0
+Version: 1.47.0
 Date: 2024-03-12
 Author: Joseph Nathaniel Paulson, Nathan D. Olson, Domenick J. Braccia, 
     Justin Wagner, Hisham Talukder, Mihai Pop, Hector Corrada Bravo

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: metagenomeSeq
 Title: Statistical analysis for sparse high-throughput sequencing
-Version: 1.45.2
+Version: 1.46.0
 Date: 2024-03-12
 Author: Joseph Nathaniel Paulson, Nathan D. Olson, Domenick J. Braccia, 
     Justin Wagner, Hisham Talukder, Mihai Pop, Hector Corrada Bravo

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: metagenomeSeq
 Title: Statistical analysis for sparse high-throughput sequencing
-Version: 1.49.0
-Date: 2024-03-12
+Version: 1.49.1
+Date: 2024-12-10
 Author: Joseph Nathaniel Paulson, Nathan D. Olson, Domenick J. Braccia, 
     Justin Wagner, Hisham Talukder, Mihai Pop, Hector Corrada Bravo
 Maintainer: Joseph N. Paulson <josephpaulson@gmail.com>

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: metagenomeSeq
 Title: Statistical analysis for sparse high-throughput sequencing
-Version: 1.32.0
+Version: 1.33.0
 Date: 2019-07-12
 Author: Joseph Nathaniel Paulson, Nathan D. Olson, Domenick J. Braccia, 
     Justin Wagner, Hisham Talukder, Mihai Pop, Hector Corrada Bravo

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: metagenomeSeq
 Title: Statistical analysis for sparse high-throughput sequencing
-Version: 1.45.0
-Date: 2019-07-12
+Version: 1.45.1
+Date: 2024-03-12
 Author: Joseph Nathaniel Paulson, Nathan D. Olson, Domenick J. Braccia, 
     Justin Wagner, Hisham Talukder, Mihai Pop, Hector Corrada Bravo
 Maintainer: Joseph N. Paulson <jpaulson@jimmy.harvard.edu>

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,10 +1,10 @@
 Package: metagenomeSeq
 Title: Statistical analysis for sparse high-throughput sequencing
-Version: 1.45.1
+Version: 1.45.2
 Date: 2024-03-12
 Author: Joseph Nathaniel Paulson, Nathan D. Olson, Domenick J. Braccia, 
     Justin Wagner, Hisham Talukder, Mihai Pop, Hector Corrada Bravo
-Maintainer: Joseph N. Paulson <jpaulson@jimmy.harvard.edu>
+Maintainer: Joseph N. Paulson <josephpaulson@gmail.com>
 Description: metagenomeSeq is designed to determine features (be it
     Operational Taxanomic Unit (OTU), species, etc.) that are
     differentially abundant between two or more groups of multiple

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: metagenomeSeq
 Title: Statistical analysis for sparse high-throughput sequencing
-Version: 1.37.0
+Version: 1.38.0
 Date: 2019-07-12
 Author: Joseph Nathaniel Paulson, Nathan D. Olson, Domenick J. Braccia, 
     Justin Wagner, Hisham Talukder, Mihai Pop, Hector Corrada Bravo

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: metagenomeSeq
 Title: Statistical analysis for sparse high-throughput sequencing
-Version: 1.44.0
+Version: 1.45.0
 Date: 2019-07-12
 Author: Joseph Nathaniel Paulson, Nathan D. Olson, Domenick J. Braccia, 
     Justin Wagner, Hisham Talukder, Mihai Pop, Hector Corrada Bravo

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: metagenomeSeq
 Title: Statistical analysis for sparse high-throughput sequencing
-Version: 1.38.0
+Version: 1.39.0
 Date: 2019-07-12
 Author: Joseph Nathaniel Paulson, Nathan D. Olson, Domenick J. Braccia, 
     Justin Wagner, Hisham Talukder, Mihai Pop, Hector Corrada Bravo

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: metagenomeSeq
 Title: Statistical analysis for sparse high-throughput sequencing
-Version: 1.48.0
+Version: 1.49.0
 Date: 2024-03-12
 Author: Joseph Nathaniel Paulson, Nathan D. Olson, Domenick J. Braccia, 
     Justin Wagner, Hisham Talukder, Mihai Pop, Hector Corrada Bravo

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: metagenomeSeq
 Title: Statistical analysis for sparse high-throughput sequencing
-Version: 1.40.0
+Version: 1.41.0
 Date: 2019-07-12
 Author: Joseph Nathaniel Paulson, Nathan D. Olson, Domenick J. Braccia, 
     Justin Wagner, Hisham Talukder, Mihai Pop, Hector Corrada Bravo

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: metagenomeSeq
 Title: Statistical analysis for sparse high-throughput sequencing
-Version: 1.42.0
+Version: 1.43.0
 Date: 2019-07-12
 Author: Joseph Nathaniel Paulson, Nathan D. Olson, Domenick J. Braccia, 
     Justin Wagner, Hisham Talukder, Mihai Pop, Hector Corrada Bravo

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: metagenomeSeq
 Title: Statistical analysis for sparse high-throughput sequencing
-Version: 1.35.0
+Version: 1.36.0
 Date: 2019-07-12
 Author: Joseph Nathaniel Paulson, Nathan D. Olson, Domenick J. Braccia, 
     Justin Wagner, Hisham Talukder, Mihai Pop, Hector Corrada Bravo

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: metagenomeSeq
 Title: Statistical analysis for sparse high-throughput sequencing
-Version: 1.34.0
+Version: 1.35.0
 Date: 2019-07-12
 Author: Joseph Nathaniel Paulson, Nathan D. Olson, Domenick J. Braccia, 
     Justin Wagner, Hisham Talukder, Mihai Pop, Hector Corrada Bravo

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: metagenomeSeq
 Title: Statistical analysis for sparse high-throughput sequencing
-Version: 1.41.0
+Version: 1.42.0
 Date: 2019-07-12
 Author: Joseph Nathaniel Paulson, Nathan D. Olson, Domenick J. Braccia, 
     Justin Wagner, Hisham Talukder, Mihai Pop, Hector Corrada Bravo

--- a/R/fitZig.R
+++ b/R/fitZig.R
@@ -188,7 +188,7 @@ fitZig <- function(obj,
     fit$residuals <- sweep((y-countMu), 1, fit$fit$sigma, "/")
   }
   
-  eb <- limma::eBayes(fit$fit)
+  eb <- limma::eBayes(fit$fit, legacy = TRUE)
   dat <- list(fit=fit$fit, countResiduals=fit$residuals,
               z=z, zUsed=zUsed, eb=eb, zeroMod=zero_model_matrix, stillActive=stillActive,
               stillActiveNLL=stillActiveNLL, zeroCoef=zeroCoef, dupcor=dupcor)

--- a/tests/testthat/test-norm.R
+++ b/tests/testthat/test-norm.R
@@ -25,13 +25,13 @@ test_that("`cumNorm` returns the same object as defined in the package", {
 
 test_that("`cumNormStat` returns the correct value", {
   data(lungData); data(mouseData);
-  expect_equal(cumNormStat(lungData),0.7014946)
-  expect_equal(cumNormStat(mouseData),0.5)
+  expect_equal(as.numeric(cumNormStat(lungData)),0.7014946)
+  expect_equal(as.numeric(cumNormStat(mouseData)),0.5)
 })
 
 test_that("`cumNormStatFast` returns the correct value", {
   data(lungData); data(mouseData);
-  expect_equal(cumNormStatFast(lungData),0.7014946)
-  expect_equal(cumNormStatFast(mouseData),0.5)
+  expect_equal(as.numeric(cumNormStatFast(lungData)),0.7014946)
+  expect_equal(as.numeric(cumNormStatFast(mouseData)),0.5)
 })
 

--- a/vignettes/metagenomeSeq.Rnw
+++ b/vignettes/metagenomeSeq.Rnw
@@ -50,11 +50,11 @@ Analyzing high-throughput sequencing data has been a challenge to researchers du
  White \textit{et al.}'s Metastats and Segata \textit{et al.}'s LEfSe. The first is a non-parametric permutation test on $t$-statistics and the second is a non-parametric Kruskal-Wallis test followed by subsequent wilcox rank-sum tests on subgroups to guard against positive discoveries of differential abundance driven by potential confounders - neither address normalization nor sparsity.
 
 This vignette describes the basic protocol when using \texttt{metagenomeSeq}. 
-A normalization method able to control for biases in measurements across taxanomic features and a mixture model that implements a zero-inflated Gaussian distribution to account for varying depths of coverage are implemented.
+A normalization method able to control for biases in measurements across taxonomic features and a mixture model that implements a zero-inflated Gaussian distribution to account for varying depths of coverage are implemented.
 Using a linear model methodology, it is easy to include confounding sources of variability and interpret results. 
 Additionally, visualization functions are provided to examine discoveries. 
 
-The software was designed to determine features (be it Operational Taxanomic Unit (OTU), species, etc.) that are differentially abundant between two or more groups of multiple samples. 
+The software was designed to determine features (be it Operational Taxonomic Unit (OTU), species, etc.) that are differentially abundant between two or more groups of multiple samples. 
 The software was also designed to address the effects of both normalization and undersampling of microbial communities on disease association detection and testing of feature correlations.
 
 \begin{figure}
@@ -689,7 +689,7 @@ The S4 class system in R allows for object oriented definitions. \texttt{metagen
 
 The experiment summary slot is a data frame that includes the depth of coverage and the normalization factors for each sample. Future datasets can be formated as MRexperiment objects and analyzed with relative ease. A \texttt{MRexperiment} object is created by calling \texttt{newMRexperiment}, passing the counts, phenotype and feature data as parameters.
 
-We do not include normalization factors or library size in the currently available slot specified for the sample specific phenotype data. All matrices are organized in the \texttt{assayData} slot. All phenotype data (disease status, age, etc.) is stored in \texttt{phenoData} and feature data (OTUs, taxanomic assignment to varying levels, etc.) in \texttt{featureData}. Additional slots are available for reproducibility and annotation.
+We do not include normalization factors or library size in the currently available slot specified for the sample specific phenotype data. All matrices are organized in the \texttt{assayData} slot. All phenotype data (disease status, age, etc.) is stored in \texttt{phenoData} and feature data (OTUs, taxonomic assignment to varying levels, etc.) in \texttt{featureData}. Additional slots are available for reproducibility and annotation.
 
 \subsection{Appendix B: Mathematical model}
 


### PR DESCRIPTION
The package is currently failing two unit tests on the Bioconductor build system, which is causing packages that depend on metagenomeSeq to be unavailable:

https://bioconductor.org/checkResults/release/bioc-LATEST/metagenomeSeq/

The cause of the failures appears to be changes to `limma::eBayes()`, which means the computed values no longer match the saved versions they're being compared to in the tests.  This patch enables the 'legacy' behaviou of `eBayes()`, which is a quick solution, although it may be more appropriate to use the new version and update the stored values.